### PR TITLE
Switch to 'git switch' command in delete_squashed_branch.sh script

### DIFF
--- a/.github/delete_squashed_branch.sh
+++ b/.github/delete_squashed_branch.sh
@@ -1,5 +1,5 @@
 #https://stackoverflow.com/questions/41946475/git-why-cant-i-delete-my-branch-after-a-squash-merge
-git checkout main
+git switch main
 git fetch
 git pull
 


### PR DESCRIPTION
This pull request updates the 'delete_squashed_branch.sh' script to use the 'git switch' command instead of 'git checkout'. This change improves consistency and aligns with the latest Git best practices.